### PR TITLE
Fix SupportTable modal usage

### DIFF
--- a/src/views/account_details/support/SupportTable.component.tsx
+++ b/src/views/account_details/support/SupportTable.component.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React from 'react';
+import React, { useState } from 'react';
 import styles from './Support.module.scss';
 import SearchWrapper from '@/layout/searchWrapper/SearchWrapper.layout';
 import { useRouter } from 'next/navigation';
@@ -33,34 +33,43 @@ const SupportTable = () => {
   }) as any;
 
   const [form] = Form.useForm();
+  const [createModalOpen, setCreateModalOpen] = useState(false);
+
+  const handleCreate = () => {
+    form
+      .validateFields()
+      .then((values) => {
+        createTicket({
+          formData: values,
+        });
+        setCreateModalOpen(false);
+      })
+      .catch((info) => {
+        console.log('Validate Failed:', info);
+      });
+  };
 
   return (
-    <SearchWrapper
-      buttons={[
-        {
-          toolTip: 'Create new Support request',
-          icon: <AiOutlinePlus className={styles.icon} />,
-          onClick: () => {
-            Modal.info({
-              title: 'Create new Support request',
-              content: <SupportForm form={form} />,
-              onOk() {
-                form
-                  .validateFields()
-                  .then((values) => {
-                    createTicket({
-                      formData: values,
-                    });
-                  })
-                  .catch((info) => {
-                    console.log('Validate Failed:', info);
-                  });
-              },
-            });
+    <>
+      <Modal
+        open={createModalOpen}
+        title="Create new Support request"
+        onOk={handleCreate}
+        onCancel={() => setCreateModalOpen(false)}
+      >
+        <SupportForm form={form} />
+      </Modal>
+      <SearchWrapper
+        buttons={[
+          {
+            toolTip: 'Create new Support request',
+            icon: <AiOutlinePlus className={styles.icon} />,
+            onClick: () => {
+              setCreateModalOpen(true);
+            },
+            type: 'primary',
           },
-          type: 'primary',
-        },
-      ]}
+        ]}
       placeholder="Search for ministries"
       total={data?.payload?.totalCount}
       queryKey={'ministryList'}
@@ -158,6 +167,7 @@ const SupportTable = () => {
         />
       </div>
     </SearchWrapper>
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary
- refactor support request creation modal to use `<Modal />` component
- manage modal visibility with state

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6845e35060948320b41e166a313ab3d3