### PR TITLE
Fix billing page metadata

### DIFF
--- a/src/app/billing/page.tsx
+++ b/src/app/billing/page.tsx
@@ -1,0 +1,18 @@
+import PageLayout from "@/layout/page/Page.layout";
+import { navigation } from "@/data/navigation";
+import BillingView from "@/views/billing/Billing.view";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Free Agent Portal | Billing",
+  description:
+    "Billing account center for the Free Agent Portal, the service connecting athletes with teams.",
+};
+
+export default function Component() {
+  return (
+    <PageLayout pages={[navigation().billing.links.account_center]}>
+      <BillingView />
+    </PageLayout>
+  );
+}

--- a/src/data/navigation.tsx
+++ b/src/data/navigation.tsx
@@ -46,6 +46,18 @@ export const navigation = (options?: any) => {
       },
       hidden: options?.user ? false : true,
     },
+
+    billing: {
+      title: "Billing",
+      links: {
+        account_center: {
+          title: "Billing Account Center",
+          link: "/billing",
+          icon: <BsBox />,
+        },
+      },
+      hidden: options?.user ? false : true,
+    },
     auth: {
       title: "Auth",
       links: {


### PR DESCRIPTION
## Summary
- update billing page metadata to reference the Free Agent Portal
- keep navigation data linking to billing account center

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68460d7e918883209b529eab8890d187