### PR TITLE
Add billing setup modal and gate in AppWrapper

### DIFF
--- a/src/components/billingSetupModal/BillingSetupModal.component.tsx
+++ b/src/components/billingSetupModal/BillingSetupModal.component.tsx
@@ -1,0 +1,23 @@
+'use client';
+import { Modal } from 'antd';
+import styles from './BillingSetupModal.module.scss';
+
+type Props = {
+  open: boolean;
+};
+
+const BillingSetupModal = ({ open }: Props) => {
+  return (
+    <Modal
+      open={open}
+      closable={false}
+      footer={null}
+      maskClosable={false}
+      title="Billing Setup Required"
+    >
+      <p className={styles.text}>Please complete your billing setup to continue.</p>
+    </Modal>
+  );
+};
+
+export default BillingSetupModal;

--- a/src/components/billingSetupModal/BillingSetupModal.module.scss
+++ b/src/components/billingSetupModal/BillingSetupModal.module.scss
@@ -1,0 +1,5 @@
+@use '@/styles/globals.scss' as *;
+
+.text {
+  margin-bottom: 0;
+}

--- a/src/layout/appWrapper/AppWrapper.tsx
+++ b/src/layout/appWrapper/AppWrapper.tsx
@@ -5,6 +5,7 @@ import React, { useEffect } from 'react';
 import io from 'socket.io-client';
 import { useUser } from '@/state/auth';
 import { useSocketStore } from '@/state/socket';
+import BillingSetupModal from '@/components/billingSetupModal/BillingSetupModal.component';
 
 type Props = {
   children: React.ReactNode;
@@ -49,7 +50,14 @@ const AppWrapper = (props: Props) => {
       }
     };
   }, [socket]);
-  return <>{props.children}</>;
+  return (
+    <>
+      {props.children}
+      {!userIsLoading && loggedInData?.user?.needsBillingSetup && (
+        <BillingSetupModal open={true} />
+      )}
+    </>
+  );
 };
 
 export default AppWrapper;


### PR DESCRIPTION
## Summary
- add BillingSetupModal component
- wire the modal up to AppWrapper when user requires billing setup

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684615b2a0388320ab062eb7d4435c85