### PR TITLE
Add feature selection step to billing setup modal

### DIFF
--- a/src/layout/billingSetupModal/BillingSetupModal.component.tsx
+++ b/src/layout/billingSetupModal/BillingSetupModal.component.tsx
@@ -1,13 +1,27 @@
 'use client';
 import { Modal } from 'antd';
-import styles from './BillingSetupModal.module.scss'; 
+import { useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import styles from './BillingSetupModal.module.scss';
 import PaymentInformationForm from '@/views/billing/components/paymentInformation/PaymentInformation.component';
+import FeatureSelect from './FeatureSelect.component';
 
 type Props = {
   open: boolean;
 };
 
 const BillingSetupModal = ({ open }: Props) => {
+  const [step, setStep] = useState<'features' | 'payment'>('features');
+
+  const renderStep = () => {
+    switch (step) {
+      case 'payment':
+        return <PaymentInformationForm />;
+      default:
+        return <FeatureSelect onContinue={() => setStep('payment')} />;
+    }
+  };
+
   return (
     <Modal
       open={open}
@@ -17,8 +31,20 @@ const BillingSetupModal = ({ open }: Props) => {
       title="Billing Setup Required"
       className={styles.container}
     >
-      <p className={styles.text}>Before you can access your account you need to complete the billing setup process</p>
-      <PaymentInformationForm/>
+      <p className={styles.text}>
+        Before you can access your account you need to complete the billing setup process
+      </p>
+      <AnimatePresence mode="wait" initial={false}>
+        <motion.div
+          key={step}
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: 20 }}
+          transition={{ duration: 0.3, ease: 'easeInOut' }}
+        >
+          {renderStep()}
+        </motion.div>
+      </AnimatePresence>
     </Modal>
   );
 };

--- a/src/layout/billingSetupModal/FeatureSelect.component.tsx
+++ b/src/layout/billingSetupModal/FeatureSelect.component.tsx
@@ -1,0 +1,20 @@
+'use client';
+import { Button } from 'antd';
+import styles from './FeatureSelect.module.scss';
+
+type Props = {
+  onContinue: () => void;
+};
+
+const FeatureSelect = ({ onContinue }: Props) => {
+  return (
+    <div className={styles.container}>
+      <p>Select your desired features (placeholder)</p>
+      <Button type="primary" onClick={onContinue}>
+        Continue
+      </Button>
+    </div>
+  );
+};
+
+export default FeatureSelect;

--- a/src/layout/billingSetupModal/FeatureSelect.module.scss
+++ b/src/layout/billingSetupModal/FeatureSelect.module.scss
@@ -1,0 +1,9 @@
+@use '@/styles/globals.scss' as *;
+
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
+}


### PR DESCRIPTION
## Summary
- add placeholder `FeatureSelect` component
- slide between feature selection and payment form in the billing setup modal using framer-motion

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_6846306fd240832085a00246697a8bac