### PR TITLE
Add FeaturePlan card

### DIFF
--- a/src/layout/billingSetupModal/FeatureSelect.component.tsx
+++ b/src/layout/billingSetupModal/FeatureSelect.component.tsx
@@ -3,6 +3,8 @@ import { Button } from 'antd';
 import styles from './FeatureSelect.module.scss';
 import { useUser } from '@/state/auth';
 import useApiHook from '@/hooks/useApi';
+import { useState } from 'react';
+import FeaturePlanCard, { FeaturePlan } from './components/featurePlanCard/FeaturePlanCard.component';
 
 type Props = {
   onContinue: () => void;
@@ -19,10 +21,22 @@ const FeatureSelect = ({ onContinue }: Props) => {
     filter: `availableTo;{"$in":"${Object.keys(loggedInUser.profileRefs).join(',')}"}`,
   }) as any;
 
+  const [selectedPlan, setSelectedPlan] = useState<string>('');
+
+  const plans: FeaturePlan[] =
+    plansRequest?.payload?.data || plansRequest?.payload || plansRequest?.data || [];
+
   return (
     <div className={styles.container}>
-      <p>Select your desired features (placeholder)</p>
-      <Button type="primary" onClick={onContinue}>
+      {plans.map((plan: FeaturePlan) => (
+        <FeaturePlanCard
+          key={plan._id}
+          plan={plan}
+          selected={selectedPlan === plan._id}
+          onSelect={() => setSelectedPlan(plan._id)}
+        />
+      ))}
+      <Button type="primary" onClick={onContinue} disabled={!selectedPlan}>
         Continue
       </Button>
     </div>

--- a/src/layout/billingSetupModal/components/featurePlanCard/FeaturePlanCard.component.tsx
+++ b/src/layout/billingSetupModal/components/featurePlanCard/FeaturePlanCard.component.tsx
@@ -1,0 +1,40 @@
+'use client';
+import styles from './FeaturePlanCard.module.scss';
+
+export type FeaturePlan = {
+  _id: string;
+  name: string;
+  description: string;
+  price: string;
+  billingCycle?: string;
+  availableTo?: string[];
+  features?: any[];
+  isActive?: boolean;
+};
+
+interface Props {
+  plan: FeaturePlan;
+  selected?: boolean;
+  onSelect?: () => void;
+}
+
+const FeaturePlanCard = ({ plan, selected = false, onSelect }: Props) => {
+  const handleSelect = () => {
+    if (onSelect) onSelect();
+  };
+
+  return (
+    <div
+      className={`${styles.container} ${selected ? styles.active : ''}`}
+      onClick={handleSelect}
+    >
+      <h3 className={styles.name}>{plan.name}</h3>
+      <p className={styles.description}>{plan.description}</p>
+      <span className={styles.price}>
+        {Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(Number(plan.price))}
+      </span>
+    </div>
+  );
+};
+
+export default FeaturePlanCard;

--- a/src/layout/billingSetupModal/components/featurePlanCard/FeaturePlanCard.module.scss
+++ b/src/layout/billingSetupModal/components/featurePlanCard/FeaturePlanCard.module.scss
@@ -1,0 +1,35 @@
+@use '@/styles/globals.scss' as *;
+
+.container {
+  border: 1px solid var(--primary);
+  border-radius: var(--radius-md);
+  padding: 15px;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  width: 100%;
+  cursor: pointer;
+  transition: $simple-animation;
+
+  &.active {
+    background-color: var(--primary-light);
+    box-shadow: var(--shadow-default);
+  }
+
+  .name {
+    font-size: var(--font-size-md);
+    font-weight: var(--font-weight-bold);
+    color: var(--primary-dark);
+  }
+
+  .description {
+    font-size: var(--font-size-sm);
+    color: var(--secondary-dark);
+  }
+
+  .price {
+    margin-top: 5px;
+    font-weight: var(--font-weight-medium);
+    color: var(--primary-dark);
+  }
+}


### PR DESCRIPTION
## Summary
- add FeaturePlanCard component for selecting a plan
- style FeaturePlanCard
- render FeaturePlanCard options inside `FeatureSelect`

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_6847777662ac8320a8590e96b06fc456