### PR TITLE
Store selected plan in global state

### DIFF
--- a/src/layout/billingSetupModal/FeatureSelect.component.tsx
+++ b/src/layout/billingSetupModal/FeatureSelect.component.tsx
@@ -3,7 +3,7 @@ import { Button } from 'antd';
 import styles from './FeatureSelect.module.scss';
 import { useUser } from '@/state/auth';
 import useApiHook from '@/hooks/useApi';
-import { useState } from 'react';
+import { usePlansStore } from '@/state/plans';
 import FeaturePlanCard, { FeaturePlan } from './components/featurePlanCard/FeaturePlanCard.component';
 
 type Props = {
@@ -13,7 +13,7 @@ type Props = {
 const FeatureSelect = ({ onContinue }: Props) => {
   const { data: loggedInUser } = useUser();
 
-  const { data: plansRequest, isLoading } = useApiHook({
+  const { data: plansRequest } = useApiHook({
     url: `/auth/plan`,
     key: 'plan-select',
     method: 'GET',
@@ -21,7 +21,7 @@ const FeatureSelect = ({ onContinue }: Props) => {
     filter: `availableTo;{"$in":"${Object.keys(loggedInUser.profileRefs).join(',')}"}`,
   }) as any;
 
-  const [selectedPlan, setSelectedPlan] = useState<string>('');
+  const { selectedPlans, selectPlan } = usePlansStore();
 
   const plans: FeaturePlan[] =
     plansRequest?.payload?.data || plansRequest?.payload || plansRequest?.data || [];
@@ -32,11 +32,11 @@ const FeatureSelect = ({ onContinue }: Props) => {
         <FeaturePlanCard
           key={plan._id}
           plan={plan}
-          selected={selectedPlan === plan._id}
-          onSelect={() => setSelectedPlan(plan._id)}
+          selected={selectedPlans.some((p) => p._id === plan._id)}
+          onSelect={() => selectPlan(plan)}
         />
       ))}
-      <Button type="primary" onClick={onContinue} disabled={!selectedPlan}>
+      <Button type="primary" onClick={onContinue} disabled={selectedPlans.length === 0}>
         Continue
       </Button>
     </div>

--- a/src/state/plans.ts
+++ b/src/state/plans.ts
@@ -1,0 +1,34 @@
+import { create } from 'zustand';
+import { mountStoreDevtool } from 'simple-zustand-devtools';
+import { FeaturePlan } from '@/layout/billingSetupModal/components/featurePlanCard/FeaturePlanCard.component';
+
+interface PlansState {
+  selectedPlans: FeaturePlan[];
+  togglePlan: (plan: FeaturePlan) => void;
+  /**
+   * Temporarily restricts selection to a single plan. Replaces the array with
+   * the provided plan or clears it if the plan is already selected. This keeps
+   * the store compatible with future multi-plan support.
+   */
+  selectPlan: (plan: FeaturePlan) => void;
+}
+
+export const usePlansStore = create<PlansState>((set) => ({
+  selectedPlans: [],
+  togglePlan: (plan: FeaturePlan) =>
+    set((state) => {
+      const exists = state.selectedPlans.find((p) => p._id === plan._id);
+      return exists
+        ? { selectedPlans: state.selectedPlans.filter((p) => p._id !== plan._id) }
+        : { selectedPlans: [...state.selectedPlans, plan] };
+    }),
+  selectPlan: (plan: FeaturePlan) =>
+    set((state) => {
+      const exists = state.selectedPlans.find((p) => p._id === plan._id);
+      return exists ? { selectedPlans: [] } : { selectedPlans: [plan] };
+    }),
+}));
+
+if (process.env.NODE_ENV === 'development') {
+  mountStoreDevtool('PlansStore', usePlansStore);
+}

--- a/src/views/billing/components/paymentInformation/PaymentInformation.component.tsx
+++ b/src/views/billing/components/paymentInformation/PaymentInformation.component.tsx
@@ -26,7 +26,7 @@ const PaymentInformationForm = () => {
               Bank Account (ACH)
             </div>
             <p style={{ marginTop: '1%', color: 'gray', textAlign: 'center' }}>
-              Customer account information is not stored by PyreProcessing. We take the security of your customers' information very seriously, which is why we use a third-party
+              Customer account information is not stored by PyreProcessing. We take the security of your customers&apos; information very seriously, which is why we use a third-party
               vaulting system provided by NMI. All credit card and ACH information is securely stored with them, ensuring compliance with PCI DSS standards.
             </p>
             <AchForm />
@@ -45,7 +45,7 @@ const PaymentInformationForm = () => {
               Credit/Debit Card
             </div>
             <p style={{ marginTop: '1%', color: 'gray', textAlign: 'center' }}>
-              Customer account information is not stored by PyreProcessing. We take the security of your customers' information very seriously, which is why we use a third-party
+              Customer account information is not stored by PyreProcessing. We take the security of your customers&apos; information very seriously, which is why we use a third-party
               vaulting system provided by NMI. All credit card and ACH information is securely stored with them, ensuring compliance with PCI DSS standards.
             </p>
             <CardForm />


### PR DESCRIPTION
## Summary
- add a `selectPlan` helper in the plan store
- update `FeatureSelect` to only allow one plan at a time

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68477db654d4832096d20fcb008b3b1c