### PR TITLE
Limit plan selection to single plan

### DIFF
--- a/src/state/plans.ts
+++ b/src/state/plans.ts
@@ -2,6 +2,9 @@ import { create } from 'zustand';
 import { mountStoreDevtool } from 'simple-zustand-devtools';
 import { FeaturePlan } from '@/layout/billingSetup/components/featurePlanCard/FeaturePlanCard.component';
 
+// Toggle this flag when multiple plan selection should be re-enabled
+export const ALLOW_MULTIPLE_PLAN_SELECT = false;
+
 interface PlansState {
   selectedPlans: FeaturePlan[];
   togglePlan: (plan: FeaturePlan) => void;
@@ -12,7 +15,14 @@ export const usePlansStore = create<PlansState>((set) => ({
   togglePlan: (plan: FeaturePlan) =>
     set((state) => {
       const exists = state.selectedPlans.find((p) => p._id === plan._id);
-      return exists ? { selectedPlans: state.selectedPlans.filter((p) => p._id !== plan._id) } : { selectedPlans: [...state.selectedPlans, plan] };
+      if (ALLOW_MULTIPLE_PLAN_SELECT) {
+        return exists
+          ? { selectedPlans: state.selectedPlans.filter((p) => p._id !== plan._id) }
+          : { selectedPlans: [...state.selectedPlans, plan] };
+      }
+
+      // Single plan selection mode
+      return exists ? { selectedPlans: [] } : { selectedPlans: [plan] };
     }),
 }));
 


### PR DESCRIPTION
## Summary
- add configuration flag to enable multiple plan selections
- update plans store to respect single-plan mode

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6848bf1404688320b922268091c3a9e2