### PR TITLE
Add profile dropdown to header

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -8,6 +8,9 @@ const nextConfig: NextConfig = {
     SERVICE_NAME: process.env.SERVICE_NAME,
     ENV: process.env.NODE_ENV,
     ENCRYPTION_KEY: 'asdf234as2342asdf2i;lk342342;$23423',
+    TEAMS_APP_URL: process.env.TEAMS_APP_URL,
+    ADMIN_APP_URL: process.env.ADMIN_APP_URL,
+    SCOUT_APP_URL: process.env.SCOUT_APP_URL,
   },
   images: {
     remotePatterns: [

--- a/src/layout/header/Header.layout.tsx
+++ b/src/layout/header/Header.layout.tsx
@@ -1,6 +1,6 @@
 import styles from './Header.module.scss';
 import { RxHamburgerMenu } from 'react-icons/rx';
-import { Avatar, Breadcrumb, Tooltip } from 'antd';
+import { Avatar, Breadcrumb, Tooltip, Dropdown } from 'antd';
 import Link from 'next/link';
 import { useUser, logout } from '@/state/auth';
 import { BiLogOutCircle } from 'react-icons/bi';
@@ -15,6 +15,23 @@ type Props = {
 const Header = (props: Props) => {
   const toggleSideBar = useLayoutStore((state) => state.toggleSideBar);
   const { data: loggedInData } = useUser();
+  const profiles = Object.keys(loggedInData?.profileRefs || {});
+
+  const profileItems = profiles.map((p) => ({
+    key: p,
+    label: p.charAt(0).toUpperCase() + p.slice(1),
+    onClick: () => {
+      if (p === 'athlete') return;
+      const urls: Record<string, string | undefined> = {
+        team: process.env.TEAMS_APP_URL,
+        admin: process.env.ADMIN_APP_URL,
+        scout: process.env.SCOUT_APP_URL,
+      };
+      const url = urls[p];
+      if (url)
+        window.open(`${url}/?token=${loggedInData?.token}`);
+    },
+  }));
   return (
     <div className={styles.header}>
       <div className={styles.headerLeft}>
@@ -62,6 +79,13 @@ const Header = (props: Props) => {
               </div>
               <Avatar src={loggedInData?.profileImageUrl ?? '/images/no-photo.png'} className={styles.avatar} />
             </div>
+            {profiles.length > 1 ? (
+              <Dropdown menu={{ items: profileItems }}>
+                <span className={styles.profileButton}>Profiles</span>
+              </Dropdown>
+            ) : profiles.length === 1 ? (
+              <span className={styles.profileButton}>{profileItems[0]?.label}</span>
+            ) : null}
             <Notifications />
             <Tooltip title="Logout">
               <span

--- a/src/layout/header/Header.module.scss
+++ b/src/layout/header/Header.module.scss
@@ -85,6 +85,11 @@
         }
       }
 
+      .profileButton {
+        cursor: pointer;
+        color: var(--primary-dark);
+      }
+
       .logoutIcon {
         cursor: pointer;
         font-size: 20px;


### PR DESCRIPTION
## Summary
- add external app URLs to Next.js config
- style header to show profile selection
- support profile dropdown in `Header`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684b031ab8cc832080a1f1bed7f0c892